### PR TITLE
adds Apache license file link in README.md, fix #587

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Visit our docs [here](https://trigger.dev/docs).
 
 We provide an official trigger.dev docker image you can use to easily self-host the platform. We're working on more extensive guides but we currently provide a [Fly.io example repository](https://github.com/triggerdotdev/fly.io) with instructions in the README for deploying and using a self-hosted instance of Trigger.dev on Fly.io.
 
+## License
+
+[trigger.dev](https://github.com/triggerdotdev/trigger.dev) is licensed under  Apache-2.0 license. Please see [License File](https://github.com/triggerdotdev/trigger.dev/blob/main/LICENSE) for more information.
+
 ## Development
 
 To setup and develop locally or contribute to the open source project, follow our [development guide](./CONTRIBUTING.md).


### PR DESCRIPTION
fix #587

Closes #587

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I tested it locally on a markdown previewer

---

## Changelog

It shows the license section in the README.md now

---

## Screenshots

![Screenshot 2023-10-10 173154](https://github.com/ayushsgithub/trigger.dev/assets/120788538/0ce55857-0408-482f-86c1-2951bcafde24)